### PR TITLE
fix(list): gracefully handle missing pids.json file

### DIFF
--- a/internal/tunnel/pids.go
+++ b/internal/tunnel/pids.go
@@ -38,7 +38,11 @@ func SavePID(info PIDInfo) error {
 func ListPIDs() error {
 	data, err := os.ReadFile(pidsFilePath)
 	if err != nil {
-		return fmt.Errorf("could not read pids file: %w", err)
+		if os.IsNotExist(err) {
+			fmt.Println("No active port-forward sessions found.")
+			return nil
+		}
+		return fmt.Errorf("list sessions failed: could not read pids file: %w", err)
 	}
 
 	var pids []PIDInfo


### PR DESCRIPTION
Avoids error on first run when no sessions exist yet. Shows a friendly message instead. Closes #6