### PR TITLE
feat: ECS container exec via SSM + docker exec

### DIFF
--- a/cmd/ecs.go
+++ b/cmd/ecs.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/antero-software/antero-ssm-connect/internal/aws"
+	"github.com/antero-software/antero-ssm-connect/internal/ui"
+	"github.com/manifoldco/promptui"
+)
+
+// StartECSSession lets the user pick a cluster → task → container,
+// then SSMs into the underlying EC2 host and runs docker exec.
+// If clusterFilter is non-empty the cluster selection prompt is skipped.
+func StartECSSession(profile, clusterFilter string) error {
+	var selectedCluster aws.ECSCluster
+
+	if clusterFilter != "" {
+		selectedCluster = aws.ECSCluster{ARN: clusterFilter, Name: clusterFilter}
+	} else {
+		clusters, err := aws.FetchECSClusters(profile)
+		if err != nil {
+			return fmt.Errorf("fetch clusters failed: %w", err)
+		}
+		if len(clusters) == 0 {
+			return fmt.Errorf("no ECS clusters found for profile %s", profile)
+		}
+
+		clusterOptions := make([]string, len(clusters))
+		for i, c := range clusters {
+			clusterOptions[i] = c.Name
+		}
+
+		clusterPrompt := promptui.Select{
+			Label: fmt.Sprintf("Select ECS cluster (profile: %s)", profile),
+			Items: clusterOptions,
+			Searcher: func(input string, index int) bool {
+				return strings.Contains(strings.ToLower(clusterOptions[index]), strings.ToLower(input))
+			},
+		}
+
+		clusterIdx, _, err := clusterPrompt.Run()
+		if err != nil {
+			return fmt.Errorf("cluster selection cancelled: %w", err)
+		}
+
+		selectedCluster = clusters[clusterIdx]
+	}
+
+	fmt.Printf("\n⏳ Fetching running tasks in cluster: %s\n", selectedCluster.Name)
+
+	tasks, err := aws.FetchECSTasks(profile, selectedCluster.ARN)
+	if err != nil {
+		return fmt.Errorf("fetch tasks failed: %w", err)
+	}
+	if len(tasks) == 0 {
+		return fmt.Errorf("no running tasks found in cluster %s", selectedCluster.Name)
+	}
+
+	// Pick task
+	taskOptions := make([]string, len(tasks))
+	for i, t := range tasks {
+		containerNames := make([]string, len(t.Containers))
+		for j, c := range t.Containers {
+			containerNames[j] = c.Name
+		}
+		taskOptions[i] = fmt.Sprintf("%-40s  task: %s  [%s]",
+			t.ServiceName, shortID(t.TaskID), strings.Join(containerNames, ", "))
+	}
+
+	taskPrompt := promptui.Select{
+		Label: "Select ECS task",
+		Items: taskOptions,
+		Size:  20,
+		Searcher: func(input string, index int) bool {
+			return strings.Contains(strings.ToLower(taskOptions[index]), strings.ToLower(input))
+		},
+	}
+
+	taskIdx, _, err := taskPrompt.Run()
+	if err != nil {
+		return fmt.Errorf("task selection cancelled: %w", err)
+	}
+
+	selectedTask := tasks[taskIdx]
+
+	if selectedTask.ContainerInstanceARN == "" {
+		return fmt.Errorf("this task runs on Fargate — direct docker exec is not supported (no underlying EC2 host)")
+	}
+
+	// Pick container (skip prompt if only one)
+	selectedContainer := selectedTask.Containers[0]
+	if len(selectedTask.Containers) > 1 {
+		containerNames := make([]string, len(selectedTask.Containers))
+		for i, c := range selectedTask.Containers {
+			containerNames[i] = c.Name
+		}
+		containerPrompt := promptui.Select{
+			Label: "Select container",
+			Items: containerNames,
+		}
+		containerIdx, _, err := containerPrompt.Run()
+		if err != nil {
+			return fmt.Errorf("container selection cancelled: %w", err)
+		}
+		selectedContainer = selectedTask.Containers[containerIdx]
+	}
+
+	if selectedContainer.RuntimeID == "" {
+		return fmt.Errorf("container '%s' has no runtime ID — it may not be fully started yet", selectedContainer.Name)
+	}
+
+	fmt.Printf("\n⏳ Resolving EC2 host for task %s...\n", shortID(selectedTask.TaskID))
+
+	ec2InstanceID, err := aws.FetchEC2InstanceFromContainerInstance(profile, selectedCluster.ARN, selectedTask.ContainerInstanceARN)
+	if err != nil {
+		return fmt.Errorf("resolve EC2 instance failed: %w", err)
+	}
+
+	fmt.Printf("✅ Connecting to container '%s' via %s\n\n", selectedContainer.Name, ec2InstanceID)
+
+	awsPath, err := exec.LookPath("aws")
+	if err != nil {
+		return fmt.Errorf("aws CLI not found in PATH: %w", err)
+	}
+
+	dockerCmd := fmt.Sprintf("docker exec -it %s /bin/bash", selectedContainer.RuntimeID)
+
+	return syscall.Exec(awsPath, []string{
+		"aws", "ssm", "start-session",
+		"--profile", profile,
+		"--target", ec2InstanceID,
+		"--document-name", "AWS-StartInteractiveCommand",
+		"--parameters", fmt.Sprintf(`{"command":["%s"]}`, dockerCmd),
+	}, os.Environ())
+}
+
+func StartECSSessionWithPrompt(clusterFilter string) error {
+	profiles, err := aws.FetchProfiles()
+	if err != nil {
+		return err
+	}
+
+	profile, err := ui.PromptProfile(profiles)
+	if err != nil {
+		return err
+	}
+
+	return StartECSSession(profile, clusterFilter)
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -14,6 +14,7 @@ type Action string
 
 const (
 	ActionSSMSession  Action = "🧩 Start a shell session (SSM)"
+	ActionECSSession  Action = "🐳 Connect to an ECS container"
 	ActionPortForward Action = "🔌 Port-forward to a database"
 	ActionList        Action = "📋 List active sessions"
 	ActionKillAll     Action = "❌ Kill all sessions"
@@ -32,6 +33,8 @@ func Interactive() error {
 	switch action {
 	case ActionSSMSession:
 		return StartSSMSessionWithPrompt()
+	case ActionECSSession:
+		return StartECSSessionWithPrompt("")
 	case ActionPortForward:
 		return runPortForward()
 	case ActionList:
@@ -52,6 +55,7 @@ func Interactive() error {
 func promptMainAction() (Action, error) {
 	options := []Action{
 		ActionSSMSession,
+		ActionECSSession,
 		ActionPortForward,
 		ActionList,
 		ActionKillAll,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/antero-software/antero-ssm-connect
 go 1.24.2
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/aws-sdk-go-v2 v1.41.2
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.212.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.46.0
@@ -17,15 +17,16 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.73.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/aws/smithy-go v1.24.1 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2 v1.41.2 h1:LuT2rzqNQsauaGkPK/7813XxcZ3o3yePY0Iy891T2ls=
+github.com/aws/aws-sdk-go-v2 v1.41.2/go.mod h1:IvvlAZQXvTXznUPfRVfryiG1fbzE2NGK6m9u39YQ+S4=
 github.com/aws/aws-sdk-go-v2/config v1.29.14 h1:f+eEi/2cKCg9pqKBoAIwRGzVb70MRKqWX4dg1BDcSJM=
 github.com/aws/aws-sdk-go-v2/config v1.29.14/go.mod h1:wVPHWcIFv3WO89w0rE10gzf17ZYy+UVS1Geq8Iei34g=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.67 h1:9KxtdcIA/5xPNQyZRgUSpYOE6j9Bc4+D7nZua0KGYOM=
@@ -8,12 +10,18 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 h1:x793wxmUWVDhshP8WW2mln
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30/go.mod h1:Jpne2tDnYiFascUEs2AWHJL9Yp7A5ZVy3TNyxaAjD6M=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 h1:ZK5jHhnrioRkUNOc+hOgQKlUL5JeC3S6JgLxtQ+Rm0Q=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34/go.mod h1:p4VfIceZokChbA9FzMbRGz5OV+lekcVtHlPKEO0gSZY=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18 h1:F43zk1vemYIqPAwhjTjYIz0irU2EY7sOb/F5eJ3HuyM=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18/go.mod h1:w1jdlZXrGKaJcNoL+Nnrj+k5wlpGXqnNrKoP22HvAug=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 h1:SZwFm17ZUNNg5Np0ioo/gq8Mn6u9w19Mri8DnJ15Jf0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34/go.mod h1:dFZsC0BLo346mvKQLWmoJxT+Sjp+qcVR1tRVHQGOH9Q=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18 h1:xCeWVjj0ki0l3nruoyP2slHsGArMxeiiaoPN5QZH6YQ=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18/go.mod h1:r/eLGuGCBw6l36ZRWiw6PaZwPXb6YOj+i/7MizNl5/k=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.212.0 h1:z5thR/zKUlw7gd1OT59xBHm4AKBf2kPXKHFvVzLMfBk=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.212.0/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.73.0 h1:bZAxMktXWPmeWhB6I14LsJE2e+t6uLASV80xZdqqXlk=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.73.0/go.mod h1:DdtkqcURi9GM8f9HVLzJLTvS0h0k1qYg39vKQFmeR/k=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.46.0 h1:UficfhqlA7k0zQ/x9pNKmyIIeHfvJUfdbzOQJKGJkt8=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.46.0/go.mod h1:477YEP4FkrM0oUcw+w4vk4+XTB7WacLzPGPFj69kwkg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
@@ -32,6 +40,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/Xv
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.24.1 h1:VbyeNfmYkWoxMVpGUAbQumkODcYmfMRfZ8yQiH30SK0=
+github.com/aws/smithy-go v1.24.1/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=

--- a/internal/aws/ecs.go
+++ b/internal/aws/ecs.go
@@ -1,0 +1,215 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+)
+
+// ECSCluster represents an ECS cluster
+type ECSCluster struct {
+	ARN  string
+	Name string
+}
+
+// ECSContainer holds the name and docker runtime ID of a container in a task
+type ECSContainer struct {
+	Name      string
+	RuntimeID string // docker container ID
+}
+
+// ECSTask represents a running ECS task with its containers
+type ECSTask struct {
+	TaskARN              string
+	TaskID               string
+	ServiceName          string
+	Containers           []ECSContainer
+	Status               string
+	ContainerInstanceARN string // empty for Fargate tasks
+}
+
+// FetchECSClusters returns all ECS clusters for the given profile
+func FetchECSClusters(profile string) ([]ECSCluster, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithSharedConfigProfile(profile))
+	if err != nil {
+		return nil, fmt.Errorf("load config failed: %w", err)
+	}
+
+	ecsClient := ecs.NewFromConfig(cfg)
+
+	var arns []string
+	paginator := ecs.NewListClustersPaginator(ecsClient, &ecs.ListClustersInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			if isExpiredToken(err) {
+				if err := EnsureSSOLogin(profile); err != nil {
+					return nil, fmt.Errorf("SSO login failed: %w", err)
+				}
+				cfg, _ = config.LoadDefaultConfig(context.TODO(), config.WithSharedConfigProfile(profile))
+				ecsClient = ecs.NewFromConfig(cfg)
+				paginator = ecs.NewListClustersPaginator(ecsClient, &ecs.ListClustersInput{})
+				continue
+			}
+			return nil, fmt.Errorf("list clusters failed: %w", err)
+		}
+		arns = append(arns, page.ClusterArns...)
+	}
+
+	if len(arns) == 0 {
+		return nil, nil
+	}
+
+	desc, err := ecsClient.DescribeClusters(context.TODO(), &ecs.DescribeClustersInput{
+		Clusters: arns,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe clusters failed: %w", err)
+	}
+
+	var result []ECSCluster
+	for _, c := range desc.Clusters {
+		result = append(result, ECSCluster{
+			ARN:  *c.ClusterArn,
+			Name: *c.ClusterName,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result, nil
+}
+
+// FetchECSTasks returns all running tasks in the given cluster
+func FetchECSTasks(profile, clusterARN string) ([]ECSTask, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithSharedConfigProfile(profile))
+	if err != nil {
+		return nil, fmt.Errorf("load config failed: %w", err)
+	}
+
+	ecsClient := ecs.NewFromConfig(cfg)
+
+	var taskARNs []string
+	paginator := ecs.NewListTasksPaginator(ecsClient, &ecs.ListTasksInput{
+		Cluster:       &clusterARN,
+		DesiredStatus: "RUNNING",
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return nil, fmt.Errorf("list tasks failed: %w", err)
+		}
+		taskARNs = append(taskARNs, page.TaskArns...)
+	}
+
+	if len(taskARNs) == 0 {
+		return nil, nil
+	}
+
+	var result []ECSTask
+	for i := 0; i < len(taskARNs); i += 100 {
+		end := i + 100
+		if end > len(taskARNs) {
+			end = len(taskARNs)
+		}
+
+		desc, err := ecsClient.DescribeTasks(context.TODO(), &ecs.DescribeTasksInput{
+			Cluster: &clusterARN,
+			Tasks:   taskARNs[i:end],
+		})
+		if err != nil {
+			return nil, fmt.Errorf("describe tasks failed: %w", err)
+		}
+
+		for _, t := range desc.Tasks {
+			taskID := path.Base(*t.TaskArn)
+
+			// group looks like "service:<service-name>" or "family:<task-def>"
+			serviceName := ""
+			if t.Group != nil {
+				parts := strings.SplitN(*t.Group, ":", 2)
+				if len(parts) == 2 {
+					serviceName = parts[1]
+				} else {
+					serviceName = *t.Group
+				}
+			}
+
+			var containers []ECSContainer
+			for _, c := range t.Containers {
+				if c.Name == nil {
+					continue
+				}
+				runtimeID := ""
+				if c.RuntimeId != nil {
+					runtimeID = *c.RuntimeId
+				}
+				containers = append(containers, ECSContainer{
+					Name:      *c.Name,
+					RuntimeID: runtimeID,
+				})
+			}
+
+			containerInstanceARN := ""
+			if t.ContainerInstanceArn != nil {
+				containerInstanceARN = *t.ContainerInstanceArn
+			}
+
+			status := ""
+			if t.LastStatus != nil {
+				status = *t.LastStatus
+			}
+
+			result = append(result, ECSTask{
+				TaskARN:              *t.TaskArn,
+				TaskID:               taskID,
+				ServiceName:          serviceName,
+				Containers:           containers,
+				Status:               status,
+				ContainerInstanceARN: containerInstanceARN,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ServiceName < result[j].ServiceName
+	})
+	return result, nil
+}
+
+// FetchEC2InstanceFromContainerInstance resolves a container instance ARN to an EC2 instance ID
+func FetchEC2InstanceFromContainerInstance(profile, clusterARN, containerInstanceARN string) (string, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithSharedConfigProfile(profile))
+	if err != nil {
+		return "", fmt.Errorf("load config failed: %w", err)
+	}
+
+	ecsClient := ecs.NewFromConfig(cfg)
+
+	desc, err := ecsClient.DescribeContainerInstances(context.TODO(), &ecs.DescribeContainerInstancesInput{
+		Cluster:            &clusterARN,
+		ContainerInstances: []string{containerInstanceARN},
+	})
+	if err != nil {
+		return "", fmt.Errorf("describe container instances failed: %w", err)
+	}
+	if len(desc.ContainerInstances) == 0 || desc.ContainerInstances[0].Ec2InstanceId == nil {
+		return "", fmt.Errorf("EC2 instance ID not found for container instance")
+	}
+
+	return *desc.ContainerInstances[0].Ec2InstanceId, nil
+}
+
+func isExpiredToken(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "token expired") ||
+		strings.Contains(msg, "InvalidGrantException") ||
+		strings.Contains(msg, "failed to read cached SSO token file") ||
+		strings.Contains(msg, "failed to refresh cached credentials")
+}

--- a/main.go
+++ b/main.go
@@ -16,12 +16,14 @@ func main() {
 	kill := flag.Int("kill", 0, "Kill a port-forward session by PID")
 	killAll := flag.Bool("kill-all", false, "Kill all active port-forward sessions")
 	ssm := flag.Bool("ssm", false, "Start standard SSM shell session to EC2")
+	ecs := flag.Bool("ecs", false, "Start interactive bash session on an ECS container")
+	cluster := flag.String("cluster", "", "ECS cluster name or ARN (optional, skips cluster selection)")
 	help := flag.Bool("help", false, "Show usage information")
 	version := flag.Bool("version", false, "Show version")
 	dbPortForward := flag.Bool("db-port-forward", false, "Start port-forward to DB proxy via EC2")
 	flag.Parse()
 
-	if *ssm || *dbPortForward || (*profile == "" && *filter != "") {
+	if *ssm || *ecs || *dbPortForward || (*profile == "" && *filter != "") {
 		if err := cmd.SelectProfileIfEmpty(profile); err != nil {
 			log.Fatalf("profile selection failed: %v", err)
 		}
@@ -54,6 +56,16 @@ func main() {
 		} else {
 			if err := cmd.StartSSMSessionWithPrompt(); err != nil {
 				log.Fatalf("SSM session failed: %v", err)
+			}
+		}
+	case *ecs:
+		if *profile != "" {
+			if err := cmd.StartECSSession(*profile, *cluster); err != nil {
+				log.Fatalf("ECS session failed: %v", err)
+			}
+		} else {
+			if err := cmd.StartECSSessionWithPrompt(*cluster); err != nil {
+				log.Fatalf("ECS session failed: %v", err)
 			}
 		}
 	default:


### PR DESCRIPTION
## Summary

- Adds `--ecs` flag to connect directly to a running ECS container without knowing which EC2 node it's on
- Adds optional `--cluster` flag to skip the cluster selection prompt
- Adds **🐳 Connect to an ECS container** option to the interactive menu

## How it works

**Flow:** cluster → task → container → resolve EC2 host → SSM → `docker exec -it <runtimeID> /bin/bash`

1. Lists ECS clusters (skipped if `--cluster` is given)
2. Lists all `RUNNING` tasks in the cluster with service name, short task ID, and container names
3. If a task has multiple containers, prompts to pick one
4. Resolves the underlying EC2 instance via `ContainerInstanceArn`
5. Opens an SSM session to that EC2 host running `docker exec -it <containerRuntimeId> /bin/bash`

Fargate tasks are detected and rejected with a clear error message (no underlying EC2 host).

## Usage

```bash
# Interactive cluster + task selection
antero-ssm-connect --ecs --profile incept

# Skip cluster prompt
antero-ssm-connect --ecs --profile incept --cluster resimac-dev-cluster

# Via interactive menu (no flags)
antero-ssm-connect
# → "🐳 Connect to an ECS container"
```

## New files

- `internal/aws/ecs.go` — `FetchECSClusters`, `FetchECSTasks`, `FetchEC2InstanceFromContainerInstance`
- `cmd/ecs.go` — `StartECSSession`, `StartECSSessionWithPrompt`

## Test plan

- [ ] `--ecs --profile <profile>` shows cluster list, then task list, then connects
- [ ] `--ecs --profile <profile> --cluster <name>` skips cluster prompt
- [ ] Fargate task returns a clear error
- [ ] Container with missing runtimeId returns a clear error
- [ ] Interactive menu option works

🤖 Generated with [Claude Code](https://claude.com/claude-code)