### PR TITLE
fix(ci): use built-in GITHUB_TOKEN for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Download all artifacts
@@ -62,4 +64,4 @@ jobs:
           draft: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The v1.2.0 release run failed with `HttpError: Bad credentials` — `softprops/action-gh-release` was authenticating with `secrets.GH_PAT`, a personal access token that has expired or been revoked (previous releases up to v1.1.0 used the same workflow and succeeded, so this is a token lifecycle issue, not a workflow logic bug).
- This repo's Actions settings already have `default_workflow_permissions: write`, so the auto-provisioned `GITHUB_TOKEN` (scoped to this repo, rotated every run, never expires/needs renewal) is sufficient to create releases — switching to it removes the dependency on a manually-maintained PAT entirely.
- Also added an explicit `permissions: contents: write` on the `release` job so it doesn't silently break if the repo-wide default permission is ever tightened later.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly
- [ ] After merging, the v1.2.0 tag still points at the old workflow file (tag-triggered workflows run the version pinned to that commit), so it won't retroactively fix that run. Recommend cutting a new tag (e.g. `v1.2.1`) after this merges to verify the release completes — happy to do that once this is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)