### PR TITLE
fix(ci): use a GitHub App token for cross-repo homebrew tap push

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -15,11 +15,20 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion != 'success' }}
         run: exit 1
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: antero-software
+          repositories: homebrew-antero-ssm-connect
+
       - name: Checkout homebrew tap repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: antero-software/homebrew-antero-ssm-connect
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           path: homebrew-tap
 
       - name: Get tag from triggering commit


### PR DESCRIPTION
## Summary
- `update-homebrew.yml` failed with `Bad credentials` when checking out `antero-software/homebrew-antero-ssm-connect` — `secrets.GH_PAT` is a classic PAT last rotated 2025-05-19, now expired.
- Unlike the release workflow (fixed in #13), this job needs to push to a **different repo**, so the built-in `GITHUB_TOKEN` can't substitute for `GH_PAT` here — it's only ever scoped to the repo the workflow runs in.
- Replaced it with `actions/create-github-app-token`, which mints a short-lived installation token from a GitHub App installed only on the tap repo. No PAT to manually rotate/expire again.
- Bumped `actions/checkout@v3` → `v4` on that step too, which also drops the Node 20 deprecation warning seen in the failed run.

## ⚠️ One-time manual setup required before this will work
I can't create a GitHub App myself (needs interactive GitHub UI + org admin). Someone with admin on `antero-software` needs to:

1. **Create the App**: org Settings → Developer settings → GitHub Apps → New GitHub App
   - Any name (must be globally unique), e.g. `antero-ssm-connect-release-bot`
   - Uncheck "Active" under Webhook (not needed)
   - Repository permissions → **Contents: Read and write**
   - "Where can this GitHub App be installed?" → Only on this account
2. **Generate a private key** on the App's settings page (downloads a `.pem` file)
3. **Install the App** on the org, selecting only these two repos:
   - `antero-software/antero-ssm-connect`
   - `antero-software/homebrew-antero-ssm-connect`
4. **Add two repo secrets** on `antero-ssm-connect` (Settings → Secrets and variables → Actions):
   - `APP_ID` = the App ID (shown on the App's general settings page)
   - `APP_PRIVATE_KEY` = full contents of the downloaded `.pem` file

Once that's done, this workflow should run standalone with no further token maintenance. The old `GH_PAT` secret can be deleted afterward.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly
- [ ] Manual: after the App is set up and secrets added, trigger via a new release tag (e.g. the `v1.2.1` planned after #13 merges) and confirm the formula update commit lands in the tap repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)