### PR TITLE
revert: use renewed GH_PAT for homebrew tap push instead of GitHub App

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -15,20 +15,11 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion != 'success' }}
         run: exit 1
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: antero-software
-          repositories: homebrew-antero-ssm-connect
-
       - name: Checkout homebrew tap repo
         uses: actions/checkout@v4
         with:
           repository: antero-software/homebrew-antero-ssm-connect
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GH_PAT }}
           path: homebrew-tap
 
       - name: Get tag from triggering commit


### PR DESCRIPTION
## Summary
- #14 switched the homebrew tap push to a GitHub App installation token, but the App/`APP_ID`/`APP_PRIVATE_KEY` setup was never completed — so it now fails with `Input required and not supplied: app-id` on every run.
- `GH_PAT` has since been regenerated (fine-grained, scoped to `antero-ssm-connect` + `homebrew-antero-ssm-connect`, Contents read/write), so reverting to it unblocks this immediately instead of waiting on the App setup.
- Keeps the `actions/checkout@v3` → `v4` bump from #14 (unrelated Node 20 deprecation fix, still valid).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly
- [ ] Manual: cut a new release tag and confirm the formula update commit lands in the tap repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)